### PR TITLE
Chapter 5 navigating between pages

### DIFF
--- a/app/ui/dashboard/nav-links.tsx
+++ b/app/ui/dashboard/nav-links.tsx
@@ -3,17 +3,24 @@ import {
   HomeIcon,
   DocumentDuplicateIcon,
 } from '@heroicons/react/24/outline';
+import Link from 'next/link';
 
 // Map of links to display in the side navigation.
 // Depending on the size of the application, this would be stored in a database.
 const links = [
-  { name: 'Home', href: '/dashboard', icon: HomeIcon },
+  { name: 'Home',
+    href: '/dashboard',
+    icon: HomeIcon
+  },
   {
     name: 'Invoices',
     href: '/dashboard/invoices',
     icon: DocumentDuplicateIcon,
   },
-  { name: 'Customers', href: '/dashboard/customers', icon: UserGroupIcon },
+  { name: 'Customers',
+    href: '/dashboard/customers',
+    icon: UserGroupIcon
+  },
 ];
 
 export default function NavLinks() {
@@ -21,15 +28,16 @@ export default function NavLinks() {
     <>
       {links.map((link) => {
         const LinkIcon = link.icon;
+
         return (
-          <a
+          <Link
             key={link.name}
             href={link.href}
             className="flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3"
           >
             <LinkIcon className="w-6" />
             <p className="hidden md:block">{link.name}</p>
-          </a>
+          </Link>
         );
       })}
     </>

--- a/app/ui/dashboard/nav-links.tsx
+++ b/app/ui/dashboard/nav-links.tsx
@@ -1,29 +1,29 @@
+"use client";
+
 import {
   UserGroupIcon,
   HomeIcon,
   DocumentDuplicateIcon,
-} from '@heroicons/react/24/outline';
-import Link from 'next/link';
+} from "@heroicons/react/24/outline";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import clsx from "clsx";
 
 // Map of links to display in the side navigation.
 // Depending on the size of the application, this would be stored in a database.
 const links = [
-  { name: 'Home',
-    href: '/dashboard',
-    icon: HomeIcon
-  },
+  { name: "Home", href: "/dashboard", icon: HomeIcon },
   {
-    name: 'Invoices',
-    href: '/dashboard/invoices',
+    name: "Invoices",
+    href: "/dashboard/invoices",
     icon: DocumentDuplicateIcon,
   },
-  { name: 'Customers',
-    href: '/dashboard/customers',
-    icon: UserGroupIcon
-  },
+  { name: "Customers", href: "/dashboard/customers", icon: UserGroupIcon },
 ];
 
 export default function NavLinks() {
+  const pathname = usePathname();
+
   return (
     <>
       {links.map((link) => {
@@ -33,7 +33,12 @@ export default function NavLinks() {
           <Link
             key={link.name}
             href={link.href}
-            className="flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3"
+            className={clsx(
+              "flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3",
+              {
+                "bg-sky-100 text-blue-600":pathname === link.href,
+              }
+            )}
           >
             <LinkIcon className="w-6" />
             <p className="hidden md:block">{link.name}</p>


### PR DESCRIPTION
## In this chapter...

- `<Link>` 컴포넌트 사용하는 방법 이해하기
- `usePathname()`훅을 사용해서 활성화된 메뉴 확인하기
- Next.js에서 네비게이션이 어떻게 작동하는지 이해하기

## Why optimize navigation?

- 전통적으로 사용하는 `<a>`태그의 문제점
- 해결방안 = `<Link>` 컴포넌트 

## The `<Link>` component

- `<Link>` 컴포넌트 사용하는 방법

### Automatic code-splitting and prefetching

- Next.js는 경로 세그먼트 별로 앱의 코드를 분할해준다.
- 경로 별로 코드를 분할하면 페이지가 분리된다.
- 특정 페이지에서 오류가 나더라도, 남은 페이지들로 앱을 실행시킨다.
- 이는 앱이 멈추는 것을 줄이고, 동작을 빠르게 만들어준다.
- 배포된 환경에서 `<Link>`컴포넌트가 식별되면, Next.js는 자동으로 백그라운드에서 `prefetching`을 해준다.
- 그래서 유저가 클릭하면 즉각적으로 페이지를 보여주는 로직이다.

## Pattern : Showing active links

- 일반적으로 어떤 메뉴에 들어가면 해당 메뉴를 활성화한다.
- 메뉴에 `Home`, `Customer`, `Invoice` 세가지가 있고 ,이 중에 접속 중인 메뉴가 `Customer`라고 한다면 그 메뉴만 색상을 달리하는 등의 식별을 돕는다는 뜻
- 이를 `usePathname`과 `clsx`를 조합해서 구현한다.

## Result
<img width="3600" height="2252" alt="image" src="https://github.com/user-attachments/assets/23d6cd53-7a38-42e4-9a7f-265ed64cdda0" />
